### PR TITLE
Highlight streets with route

### DIFF
--- a/src/components/YandexMap.tsx
+++ b/src/components/YandexMap.tsx
@@ -57,23 +57,21 @@ const YandexMap = forwardRef<any, YandexMapProps>(({ streets, learnedStreets, on
         console.log('Маркер:', street.name, coords[0]);
         return;
       }
-      // Если есть линия — рисуем линию
-      const polyline = new window.ymaps.Polyline(
-        coords,
-        { balloonContent: street.name },
-        {
+      // Если есть линия — строим маршрут по дорогам между точками
+      window.ymaps.route(coords).then((route: any) => {
+        route.getPaths().options.set({
           strokeColor: isLearned ? '#4CAF50' : '#FF0000',
           strokeWidth: 8,
           opacity: 1,
           zIndex: 1000
+        });
+        mapInstanceRef.current.geoObjects.add(route);
+        objectsRef.current.push(route);
+        if (isLearned) {
+          mapInstanceRef.current.setCenter(coords[0], 15, { duration: 300 });
         }
-      );
-      mapInstanceRef.current.geoObjects.add(polyline);
-      objectsRef.current.push(polyline);
-      if (isLearned) {
-        mapInstanceRef.current.setCenter(coords[0], 15, { duration: 300 });
-      }
-      console.log('Линия:', street.name, coords);
+        console.log('Маршрут:', street.name, route.getPaths().get(0).getCoordinates());
+      });
     });
   }, [streets, learnedStreets]);
 


### PR DESCRIPTION
## Summary
- use `ymaps.route` to construct a route between the start and end of a street so the full street geometry is drawn

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851800cb1a083268b0e3654631772a9